### PR TITLE
Adjust buttons layout and styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,8 +20,8 @@
         <div class="input-area">
             <button id="add-image" class="icon-button">+</button>
             <textarea id="message-input" rows="4" placeholder="Nachricht eingeben..."></textarea>
-            <button id="send" class="icon-button">→</button>
             <button id="mic" class="icon-button">🎤</button>
+            <button id="send" class="icon-button">→</button>
         </div>
     </div>
     <script src="script.js"></script>

--- a/style.css
+++ b/style.css
@@ -15,10 +15,13 @@ body {
 }
 
 #new-chat {
-    width: 3cm;
+    width: calc(100% + 20px);
+    margin-left: -10px;
+    margin-right: -10px;
     padding: 10px;
     margin-bottom: 10px;
     font-size: 18px;
+    border: 1px solid #000;
 }
 
 #chat-list {
@@ -82,7 +85,7 @@ body {
 
 .icon-button {
     background: none;
-    border: none;
+    border: 1px solid #000;
     font-size: 28px;
     padding: 10px;
     cursor: pointer;
@@ -91,6 +94,8 @@ body {
 
 #add-image {
     margin-right: 5px;
+    background-color: #007bff;
+    color: #fff;
 }
 
 #send {
@@ -98,5 +103,7 @@ body {
 }
 
 #mic {
-    margin-left: 5px;
+    margin-left: 0;
+    background-color: #007bff;
+    color: #fff;
 }


### PR DESCRIPTION
## Summary
- reorder mic button next to text input
- style icon buttons with black borders
- highlight image and mic buttons in blue
- extend the new chat button across the sidebar

## Testing
- `npm test` *(fails: ENOENT)*

------
https://chatgpt.com/codex/tasks/task_e_684c0e8d0428832a8c7650c277f775f8