### PR TITLE
Lighten button color and adjust height

### DIFF
--- a/style.css
+++ b/style.css
@@ -90,11 +90,12 @@ body {
     padding: 10px;
     cursor: pointer;
     width: 3cm;
+    height: 4cm;
 }
 
 #add-image {
     margin-right: 5px;
-    background-color: #007bff;
+    background-color: #3399ff;
     color: #fff;
 }
 
@@ -104,6 +105,6 @@ body {
 
 #mic {
     margin-left: 0;
-    background-color: #007bff;
+    background-color: #3399ff;
     color: #fff;
 }


### PR DESCRIPTION
## Summary
- tweak `.icon-button` height to match the textarea
- make the image and mic buttons a lighter blue

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684c0f7afde0832aa9948a2e28f0f0f7