### PR TITLE
Standardize image size

### DIFF
--- a/script.js
+++ b/script.js
@@ -52,7 +52,9 @@ imageInput.addEventListener('change', () => {
     if (file) {
         const img = document.createElement('img');
         img.src = URL.createObjectURL(file);
-        img.style.maxWidth = '100%';
+        img.style.width = '8cm';
+        img.style.height = '8cm';
+        img.style.objectFit = 'contain';
         addMessage(img, 'user');
     }
     imageInput.value = '';

--- a/style.css
+++ b/style.css
@@ -67,6 +67,13 @@ body {
     text-align: left;
 }
 
+/* Standard size for images in chat messages */
+.message img {
+    width: 8cm;
+    height: 8cm;
+    object-fit: contain;
+}
+
 .input-area {
     display: flex;
     align-items: center;


### PR DESCRIPTION
## Summary
- constrain images inside messages to 8cm by 8cm
- enforce same size when attaching images via the file picker

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_684c13acc8b8832a8470ac4a910dad64